### PR TITLE
Added before_plugin_install build hook to allow Braintree Embedded Frameworks.

### DIFF
--- a/hooks/before_plugin_install.js
+++ b/hooks/before_plugin_install.js
@@ -1,0 +1,70 @@
+var fs = require('fs');
+var path = require('path');
+var shell = require('shelljs');
+var child_process = require('child_process');
+
+module.exports = function(context) {
+
+    // Temporary hack to run npm install on this plugin's package.json dependencies.
+    var pluginDir = path.resolve(__dirname, '../');
+
+    child_process.execSync('npm --prefix ' + pluginDir + ' install ' + pluginDir);
+    var xcode = require('xcode');
+
+    // Need a promise so that the install waits for us to complete our project modifications
+    // before the plugin gets installed.
+    var Q = context.requireCordovaModule('q');
+    var deferral = new Q.defer();
+
+    var platforms = context.opts.cordova.platforms;
+
+    // We need to add the Braintree frameworks to the project here.
+    // They need to be embedded binaries and cordova does not yet support that.
+    // We will use node-xcode directy to add them since that library has
+    // been upgraded to support embedded binaries.
+    if (platforms.indexOf("ios") !== -1) {
+
+	// Cordova libs to get the project path and project name so we can locate the xcode project file
+        var cordova_util = context.requireCordovaModule("cordova-lib/src/cordova/util"),
+            ConfigParser = context.requireCordovaModule('cordova-lib').configparser,
+            projectRoot = cordova_util.isCordova(),
+            xml = cordova_util.projectConfig(projectRoot),
+            cfg = new ConfigParser(xml);
+
+    	var projectPath = path.join(projectRoot, 'platforms', 'ios', cfg.name() + '.xcodeproj', 'project.pbxproj');
+	var xcodeProject = xcode.project(projectPath);
+
+        xcodeProject.parse(function(err) {
+
+            if (err){
+                // Whoops
+                shell.echo('Error: ' + JSON.stringify(err));
+		deferral.resolve();
+            }
+            else {
+    
+		// Cordova project should not have more that one target.
+		var targetUUID = xcodeProject.getFirstTarget().uuid;
+
+		// First check to see if the Embed Framework node exists, if not, add it.
+		// This is all we need to do as they are added to the embedded section by default.
+		if (!xcodeProject.pbxEmbedFrameworksBuildPhaseObj(targetUUID)) {
+			xcodeProject.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Embed Frameworks', targetUUID,  null);
+			shell.echo('Adding Embedded Build Phase');
+		}
+		else {
+			shell.echo('Embedded Build Phase already added');
+		}
+
+		// Save the project file back to disk.
+                fs.writeFileSync(projectPath, xcodeProject.writeSync(), 'utf-8');
+	    	deferral.resolve();
+            }
+	});
+    }
+    else {
+	deferral.resolve();
+    }
+    return deferral.promise;
+};
+

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "cordova-android",
     "cordova-ios"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "xcode": "git://github.com/alunny/node-xcode.git#be6005e97ebbda7826e4222f64d9d19d3190f1e2"
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -12,6 +12,8 @@
 
     <license>MIT</license>
 
+    <hook type="before_plugin_install" src="hooks/before_plugin_install.js" />
+
     <!-- JavaScript Interface -->
     <js-module src="www/braintree-plugin.js" name="BraintreePlugin">
         <clobbers target="BraintreePlugin" />

--- a/typings/cordova-plugin-braintree.d.ts
+++ b/typings/cordova-plugin-braintree.d.ts
@@ -91,7 +91,7 @@ declare module BraintreePlugin {
              * BTCardNetworkUKMaestro
              */
             network: string;
-        }
+        };
 
         /**
          * Information about the PayPal account used to complete a payment (if a PayPal account was used).
@@ -105,13 +105,13 @@ declare module BraintreePlugin {
             shippingAddress: string;
             clientMetadataId: string;
             payerId: string;
-        }
+        };
 
         /**
          * Information about the Apple Pay card used to complete a payment (if Apple Pay was used).
          */
         applePaycard: {
-        }
+        };
 
         /**
          * Information about 3D Secure card used to complete a payment (if 3D Secure was used).
@@ -119,14 +119,14 @@ declare module BraintreePlugin {
         threeDSecureCard: {
             liabilityShifted: boolean;
             liabilityShiftPossible: boolean;
-        }
+        };
 
         /**
          * Information about Venmo account used to complete a payment (if a Venmo account was used).
          */
         venmoAccount: {
             username: string;
-        }
+        };
     }
 }
 

--- a/www/braintree-plugin.js
+++ b/www/braintree-plugin.js
@@ -52,8 +52,8 @@ BraintreePlugin.presentDropInPaymentUI = function showDropInUI(options, successC
     };
 
     var pluginOptions = [
-        cancelText,
-        title
+        options.cancelText,
+        options.title
     ];
 
     exec(successCallback, failureCallback, PLUGIN_ID, "presentDropInPaymentUI", pluginOptions);


### PR DESCRIPTION
- The Braintree Frameworks need to be added to iOS projects as Embedded Frameworks.  Added a build hook to use a newer version of node-xcode than the Cordova tool is currently using.  This is used to add the Embedded Framework section into the xcode project so it is there for Cordova to add to.
